### PR TITLE
Join() extension method

### DIFF
--- a/src/MarkdownGenerator/main/Model/_Extensions/EnumerableExtensions.cs
+++ b/src/MarkdownGenerator/main/Model/_Extensions/EnumerableExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Grynwald.MarkdownGenerator.Model
+{
+    public static class EnumerableExtensions
+    {
+        public static MdSpan Join(this IEnumerable<MdSpan> spans) => Join(spans, (string)null);
+
+        public static MdSpan Join(this IEnumerable<MdSpan> spans, string separator) => 
+            Join(spans, separator == null ? null : new MdTextSpan(separator));
+
+        public static MdSpan Join(this IEnumerable<MdSpan> spans, MdSpan separator)
+        {
+            // no spans to join => return empty span
+            if (!spans.Any())
+            {
+                return MdEmptySpan.Instance;
+            }
+            // a single span to join => just return the single span
+            else if (!spans.Skip(1).Any())
+            {
+                return spans.Single();
+            }
+            // multiple span but no separator => create composite span will all the specified spans
+            else if(separator == null)
+            {
+                return new MdCompositeSpan(spans);
+            }
+            // multiple spans and separator specified 
+            // => create composite span and add separator between individual spans
+            else
+            {
+                var composite = new MdCompositeSpan();
+                
+                foreach(var span in spans)
+                {
+                    if(composite.Spans.Count > 0)
+                    {
+                        composite.Add(separator.Copy());
+                    }
+                    composite.Add(span);
+                }
+
+                return composite;
+            }            
+        }
+              
+    }
+}

--- a/src/MarkdownGenerator/main/Model/_Spans/MdCodeSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdCodeSpan.cs
@@ -18,5 +18,8 @@ namespace Grynwald.MarkdownGenerator.Model
         /// <param name="text">The content of the code span. The value will not be escaped.</param>
         public MdCodeSpan(string text) => 
             Text = text ?? throw new ArgumentNullException(nameof(text));
+
+
+        public override MdSpan Copy() => new MdCodeSpan(Text);
     }
 }

--- a/src/MarkdownGenerator/main/Model/_Spans/MdCompositeSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdCompositeSpan.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Grynwald.MarkdownGenerator.Model
 {
@@ -9,10 +10,10 @@ namespace Grynwald.MarkdownGenerator.Model
     /// </summary>
     public sealed class MdCompositeSpan : MdSpan, IEnumerable<MdSpan>
     {
-        private readonly LinkedList<MdSpan> m_Spans;
+        private readonly List<MdSpan> m_Spans;
 
 
-        public IEnumerable<MdSpan> Spans { get; }
+        public IReadOnlyList<MdSpan> Spans => m_Spans;
 
         /// <summary>
         /// Initializes a new instance of <see cref="MdCompositeSpan"/> with the specified inline-elements.
@@ -28,7 +29,7 @@ namespace Grynwald.MarkdownGenerator.Model
             if (spans == null)
                 throw new ArgumentNullException(nameof(spans));
 
-            m_Spans = new LinkedList<MdSpan>(spans);
+            m_Spans = new List<MdSpan>(spans);
         }
 
 
@@ -40,9 +41,10 @@ namespace Grynwald.MarkdownGenerator.Model
             if (span == null)
                 throw new ArgumentNullException(nameof(span));
 
-            m_Spans.AddLast(span);
+            m_Spans.Add(span);
         }
 
+        public override MdSpan Copy() => new MdCompositeSpan(m_Spans.Select(x => x.Copy()));
 
         public IEnumerator<MdSpan> GetEnumerator() => m_Spans.GetEnumerator();
 

--- a/src/MarkdownGenerator/main/Model/_Spans/MdEmphasisSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdEmphasisSpan.cs
@@ -27,5 +27,7 @@ namespace Grynwald.MarkdownGenerator.Model
         {
             Text = text ?? throw new ArgumentNullException(nameof(text));
         }
+
+        public override MdSpan Copy() => new MdEmphasisSpan(Text.Copy());
     }
 }

--- a/src/MarkdownGenerator/main/Model/_Spans/MdEmptySpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdEmptySpan.cs
@@ -11,5 +11,7 @@ namespace Grynwald.MarkdownGenerator.Model
         private MdEmptySpan()
         {
         }
+
+        public override MdSpan Copy() => Instance;
     }
 }

--- a/src/MarkdownGenerator/main/Model/_Spans/MdEmptySpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdEmptySpan.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Grynwald.MarkdownGenerator.Model
+{
+    public sealed class MdEmptySpan : MdSpan
+    {
+        public static readonly MdEmptySpan Instance = new MdEmptySpan();
+
+        private MdEmptySpan()
+        {
+        }
+    }
+}

--- a/src/MarkdownGenerator/main/Model/_Spans/MdImageSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdImageSpan.cs
@@ -52,6 +52,9 @@ namespace Grynwald.MarkdownGenerator.Model
         {
             Description = description ?? throw new ArgumentNullException(nameof(description));
             Uri = uri ?? throw new ArgumentNullException(nameof(uri));
-        }        
+        }
+
+        public override MdSpan Copy() => new MdImageSpan(Description.Copy(), Uri);
+
     }
 }

--- a/src/MarkdownGenerator/main/Model/_Spans/MdLinkSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdLinkSpan.cs
@@ -53,6 +53,8 @@ namespace Grynwald.MarkdownGenerator.Model
         {
             Text = text ?? throw new ArgumentNullException(nameof(text));
             Uri = uri ?? throw new ArgumentNullException(nameof(uri));
-        }        
+        }
+
+        public override MdSpan Copy() => new MdLinkSpan(Text.Copy(), Uri);
     }
 }

--- a/src/MarkdownGenerator/main/Model/_Spans/MdRawMarkdownSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdRawMarkdownSpan.cs
@@ -20,5 +20,7 @@ namespace Grynwald.MarkdownGenerator.Model
         {
             Content = content ?? throw new ArgumentNullException(nameof(content));
         }
+
+        public override MdSpan Copy() => new MdRawMarkdownSpan(Content);
     }
 }

--- a/src/MarkdownGenerator/main/Model/_Spans/MdSingleLineSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdSingleLineSpan.cs
@@ -17,5 +17,7 @@ namespace Grynwald.MarkdownGenerator.Model
         {
             Content = content ?? throw new ArgumentNullException(nameof(content));
         }
+
+        public override MdSpan Copy() => new MdSingleLineSpan(Content.Copy());
     }
 }

--- a/src/MarkdownGenerator/main/Model/_Spans/MdSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdSpan.cs
@@ -16,6 +16,7 @@ namespace Grynwald.MarkdownGenerator.Model
         {
         }
 
+        public abstract MdSpan Copy();
 
         public override string ToString() =>
             m_SpanSerializer.ConvertToString(this);

--- a/src/MarkdownGenerator/main/Model/_Spans/MdStrongEmphasisSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdStrongEmphasisSpan.cs
@@ -28,5 +28,7 @@ namespace Grynwald.MarkdownGenerator.Model
         {
             Text = text ?? throw new ArgumentNullException(nameof(text));
         }
+
+        public override MdSpan Copy() => new MdStrongEmphasisSpan(Text.Copy());
     }
 }

--- a/src/MarkdownGenerator/main/Model/_Spans/MdTextSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdTextSpan.cs
@@ -22,5 +22,7 @@ namespace Grynwald.MarkdownGenerator.Model
         {
             Text = text ?? throw new ArgumentNullException(nameof(text));
         }
+
+        public override MdSpan Copy() => new MdTextSpan(Text);
     }
 }

--- a/src/MarkdownGenerator/main/Utilities/SpanSerializer.cs
+++ b/src/MarkdownGenerator/main/Utilities/SpanSerializer.cs
@@ -66,6 +66,10 @@ namespace Grynwald.MarkdownGenerator.Utilities
                     WriteTo(singleLineSpan, writer, removeLineBreaks);
                     break;
 
+                case MdEmptySpan emptySpan:
+                    // do nothing
+                    break;
+
                 default:
                     throw new NotSupportedException($"Unsupported span type {span.GetType().FullName}");
             }

--- a/src/MarkdownGenerator/test/Model/_Extensions/EnumerableExtensionsTest.cs
+++ b/src/MarkdownGenerator/test/Model/_Extensions/EnumerableExtensionsTest.cs
@@ -1,0 +1,239 @@
+﻿using Grynwald.MarkdownGenerator.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Grynwald.MarkdownGenerator.Test.Model
+{
+    public class EnumerableExtensionsTest
+    {
+
+        [Fact]
+        public void Join_returns_the_expected_span_01()
+        {
+            // ARRANGE
+            var spansToJoin = new[] { new MdTextSpan("text") };
+
+            // ACT
+            var joined = spansToJoin.Join();
+
+            // ASSERT
+            Assert.IsType<MdTextSpan>(joined);
+            Assert.Same(spansToJoin[0], joined);
+        }
+
+        [Fact]
+        public void Join_returns_the_expected_span_02()
+        {
+            // ARRANGE
+            var spansToJoin = Enumerable.Empty<MdSpan>();
+
+            // ACT
+            var joined = spansToJoin.Join();
+
+            // ASSERT
+            Assert.IsType<MdEmptySpan>(joined);            
+        }
+
+        [Fact]
+        public void Join_returns_the_expected_span_03()
+        {
+            // ARRANGE
+            var spansToJoin = new[]
+            {
+                new MdTextSpan("text"),
+                new MdTextSpan("more text")
+            };
+
+            // ACT
+            var joined = spansToJoin.Join();
+
+            // ASSERT
+            Assert.IsType<MdCompositeSpan>(joined);
+            var compositeSpan = (MdCompositeSpan)joined;
+            Assert.Equal(2, compositeSpan.Spans.Count);
+            Assert.Same(spansToJoin[0], compositeSpan.Spans[0]);
+            Assert.Same(spansToJoin[1], compositeSpan.Spans[1]);
+        }
+
+        [Fact]
+        public void Join_returns_the_expected_span_04()
+        {
+            // ARRANGE
+            var spansToJoin = new[] { new MdTextSpan("text") };
+
+            // ACT
+            var joined = spansToJoin.Join(separator: ",");
+
+            // ASSERT
+            Assert.IsType<MdTextSpan>(joined);
+            Assert.Same(spansToJoin[0], joined);
+        }
+
+        [Fact]
+        public void Join_returns_the_expected_span_05()
+        {
+            // ARRANGE
+            var spansToJoin = Enumerable.Empty<MdSpan>();
+
+            // ACT
+            var joined = spansToJoin.Join(separator: ",");
+
+            // ASSERT
+            Assert.IsType<MdEmptySpan>(joined);
+        }
+
+        [Fact]
+        public void Join_returns_the_expected_span_06()
+        {
+            // ARRANGE
+            var spansToJoin = new[]
+            {
+                new MdTextSpan("text"),
+                new MdTextSpan("more text")
+            };
+
+            // ACT
+            var joined = spansToJoin.Join(separator: ",");
+
+            // ASSERT
+            Assert.IsType<MdCompositeSpan>(joined);
+
+            var compositeSpan = (MdCompositeSpan)joined;
+            Assert.Equal(3, compositeSpan.Spans.Count);
+
+            Assert.Same(spansToJoin[0], compositeSpan.Spans[0]);
+
+            Assert.IsType<MdTextSpan>(compositeSpan.Spans[1]);
+            Assert.Equal(",", ((MdTextSpan)compositeSpan.Spans[1]).Text);
+
+            Assert.Same(spansToJoin[1], compositeSpan.Spans[2]);
+        }
+
+        [Fact]
+        public void Join_returns_the_expected_span_07()
+        {
+            // ARRANGE
+            var spansToJoin = new[]
+            {
+                new MdTextSpan("text"),  
+                new MdTextSpan("more text"), 
+                new MdTextSpan("even more text") 
+            };
+
+            // ACT
+            var joined = spansToJoin.Join(separator: ",");
+
+            // ASSERT
+            Assert.IsType<MdCompositeSpan>(joined);
+            var compositeSpan = (MdCompositeSpan)joined;
+            Assert.Equal(5, compositeSpan.Spans.Count);
+
+            Assert.Same(spansToJoin[0], compositeSpan.Spans[0]);
+
+            Assert.IsType<MdTextSpan>(compositeSpan.Spans[1]);
+            Assert.Equal(",", ((MdTextSpan)compositeSpan.Spans[1]).Text);
+
+            Assert.Same(spansToJoin[1], compositeSpan.Spans[2]);
+
+            Assert.IsType<MdTextSpan>(compositeSpan.Spans[3]);
+            Assert.Equal(",", ((MdTextSpan)compositeSpan.Spans[3]).Text);
+
+            Assert.Same(spansToJoin[2], compositeSpan.Spans[4]);
+        }
+
+
+        [Fact]
+        public void Join_returns_the_expected_span_08()
+        {
+            // ARRANGE
+            var spansToJoin = new[] { new MdTextSpan("text") };
+
+            // ACT
+            var joined = spansToJoin.Join(separator: new MdStrongEmphasisSpan(new MdTextSpan("separator")));
+
+            // ASSERT
+            Assert.IsType<MdTextSpan>(joined);
+            Assert.Same(spansToJoin[0], joined);
+        }
+
+        [Fact]
+        public void Join_returns_the_expected_span_09()
+        {
+            // ARRANGE
+            var spansToJoin = Enumerable.Empty<MdSpan>();
+
+            // ACT
+            var joined = spansToJoin.Join(separator: new MdStrongEmphasisSpan(new MdTextSpan("separator")));
+
+            // ASSERT
+            Assert.IsType<MdEmptySpan>(joined);
+        }
+
+        [Fact]
+        public void Join_returns_the_expected_span_10()
+        {
+            // ARRANGE
+            var spansToJoin = new[]
+            {
+                new MdTextSpan("text"),
+                new MdTextSpan("more text")
+            };
+
+            // ACT
+            var joined = spansToJoin.Join(separator: new MdStrongEmphasisSpan(new MdTextSpan("separator")));
+
+            // ASSERT
+            Assert.IsType<MdCompositeSpan>(joined);
+
+            var compositeSpan = (MdCompositeSpan)joined;
+            Assert.Equal(3, compositeSpan.Spans.Count);
+
+            Assert.Same(spansToJoin[0], compositeSpan.Spans[0]);
+
+            Assert.IsType<MdStrongEmphasisSpan>(compositeSpan.Spans[1]);
+            Assert.IsType<MdTextSpan>(((MdStrongEmphasisSpan)compositeSpan.Spans[1]).Text);
+            Assert.Equal("separator", ((MdTextSpan)((MdStrongEmphasisSpan)compositeSpan.Spans[1]).Text).Text);
+
+
+            Assert.Same(spansToJoin[1], compositeSpan.Spans[2]);
+        }
+
+        [Fact]
+        public void Join_returns_the_expected_span_11()
+        {
+            // ARRANGE
+            var spansToJoin = new[]
+            {
+                new MdTextSpan("text"),
+                new MdTextSpan("more text"),
+                new MdTextSpan("even more text")
+            };
+
+            // ACT
+            var joined = spansToJoin.Join(separator: new MdStrongEmphasisSpan(new MdTextSpan("separator")));
+
+            // ASSERT
+            Assert.IsType<MdCompositeSpan>(joined);
+            var compositeSpan = (MdCompositeSpan)joined;
+            Assert.Equal(5, compositeSpan.Spans.Count);
+
+            Assert.Same(spansToJoin[0], compositeSpan.Spans[0]);
+
+            Assert.IsType<MdStrongEmphasisSpan>(compositeSpan.Spans[1]);
+            Assert.IsType<MdTextSpan>(((MdStrongEmphasisSpan)compositeSpan.Spans[1]).Text);
+            Assert.Equal("separator", ((MdTextSpan)((MdStrongEmphasisSpan)compositeSpan.Spans[1]).Text).Text);
+
+            Assert.Same(spansToJoin[1], compositeSpan.Spans[2]);
+
+            Assert.IsType<MdStrongEmphasisSpan>(compositeSpan.Spans[3]);
+            Assert.IsType<MdTextSpan>(((MdStrongEmphasisSpan)compositeSpan.Spans[3]).Text);
+            Assert.Equal("separator", ((MdTextSpan)((MdStrongEmphasisSpan)compositeSpan.Spans[3]).Text).Text);
+
+            Assert.Same(spansToJoin[2], compositeSpan.Spans[4]);
+        }
+
+    }
+}

--- a/src/MarkdownGenerator/test/Utilities/SpanSerializerTest.cs
+++ b/src/MarkdownGenerator/test/Utilities/SpanSerializerTest.cs
@@ -195,6 +195,13 @@ namespace Grynwald.MarkdownGenerator.Test.Utilities
             AssertToStringEquals(expected, singleLine);
         }
 
+        [Fact]
+        public void EmptySpan_is_serialized_as_expeted()
+        {
+            AssertToStringEquals(string.Empty, MdEmptySpan.Instance);
+        }
+
+
         private void AssertToStringEquals(string expected, MdSpan span)
         {
             using (var writer = new StringWriter())


### PR DESCRIPTION
Adds the extension method IEnumerable<MdSpan>.Join() that combines multiple text spans, optionally adding a separator between them (similar to `string.Join`)