### PR TITLE
Maximum line length

### DIFF
--- a/src/MarkdownGenerator/main/Model/_Blocks/MdHeading.cs
+++ b/src/MarkdownGenerator/main/Model/_Blocks/MdHeading.cs
@@ -10,7 +10,7 @@ namespace Grynwald.MarkdownGenerator.Model
         /// <summary>
         /// The text of the heading
         /// </summary>
-        public MdSpan Text { get; }
+        public MdSingleLineSpan Text { get; }
 
         /// <summary>
         /// The level of the heading, 1 being the top-most heading
@@ -27,7 +27,17 @@ namespace Grynwald.MarkdownGenerator.Model
             if (level < 1 || level > 6)
                 throw new ArgumentOutOfRangeException(nameof(level), "Value must be in the range [1,6]");
 
-            Text = text ?? throw new ArgumentNullException(nameof(text));
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+
+            if (text is MdSingleLineSpan singleLineSpan)
+            {
+                Text = singleLineSpan;
+            }
+            else
+            {
+                Text = new MdSingleLineSpan(text);
+            }
             Level = level;
         }
 

--- a/src/MarkdownGenerator/main/Model/_Options/MdSerializationOptions.cs
+++ b/src/MarkdownGenerator/main/Model/_Options/MdSerializationOptions.cs
@@ -2,6 +2,9 @@
 {
     public class MdSerializationOptions
     {
+
+        public static readonly MdSerializationOptions Default = new MdSerializationOptions();
+
         /// <summary>
         /// Gets or sets the style for emphasized and strongly emphasized text
         /// </summary>

--- a/src/MarkdownGenerator/main/Model/_Options/MdSerializationOptions.cs
+++ b/src/MarkdownGenerator/main/Model/_Options/MdSerializationOptions.cs
@@ -31,5 +31,19 @@
         /// Gets or sets the style for ordered list items
         /// </summary>
         public MdOrderedListStyle OrderedListStyle { get; set; } = MdOrderedListStyle.Dot;
+
+        /// <summary>
+        /// The maximum length of a line in the output.
+        /// When set to a value greater than 0, linebreaks
+        /// will be inserted after the specified number of characters
+        /// when possible.        
+        /// </summary>
+        /// <remarks>
+        /// Not all types of blocks can be split into multiple lines. 
+        /// Also line breaks will only be inserted between words, so if 
+        /// the length of a word exceeds the maximum line length the max length
+        /// cannot be adhered to
+        /// </remarks>
+        public int MaxLineLength { get; set; } = -1;
     }
 }

--- a/src/MarkdownGenerator/main/Model/_Spans/MdCompositeSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdCompositeSpan.cs
@@ -49,18 +49,17 @@ namespace Grynwald.MarkdownGenerator.Model
 
         IEnumerator IEnumerable.GetEnumerator() => m_Spans.GetEnumerator();
 
-        public override string ToString()
+        public override string ToString() => ToString(MdSerializationOptions.Default);
+
+        public override string ToString(MdSerializationOptions options)
         {
             var stringBuilder = new StringBuilder();
-            foreach(var span in Spans)
+            foreach (var span in Spans)
             {
-                stringBuilder.Append(span.ToString());
+                stringBuilder.Append(span.ToString(options));
             }
             return stringBuilder.ToString();
         }
-
-        public override string ToString(MdSerializationOptions options) => ToString();
-
 
         internal override MdSpan DeepCopy() => new MdCompositeSpan(m_Spans.Select(x => x.DeepCopy()));
     }

--- a/src/MarkdownGenerator/main/Model/_Spans/MdEmphasisSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdEmphasisSpan.cs
@@ -29,24 +29,19 @@ namespace Grynwald.MarkdownGenerator.Model
         }
 
 
-        public override string ToString() => ToString(MdEmphasisStyle.Asterisk);
-       
-        public override string ToString(MdSerializationOptions options) => ToString(options.EmphasisStyle);        
+        public override string ToString() => ToString(MdSerializationOptions.Default);
 
-
-        internal override MdSpan DeepCopy() => new MdEmphasisSpan(Text.DeepCopy());
-
-        private string ToString(MdEmphasisStyle style)
+        public override string ToString(MdSerializationOptions options)
         {
-            var text = Text.ToString();
+            var text = Text.ToString(options);
 
-            if(String.IsNullOrEmpty(text))
+            if (String.IsNullOrEmpty(text))
             {
                 return String.Empty;
             }
 
             char emphasisChar;
-            switch (style)
+            switch (options.EmphasisStyle)
             {
                 case MdEmphasisStyle.Asterisk:
                     emphasisChar = '*';
@@ -56,10 +51,13 @@ namespace Grynwald.MarkdownGenerator.Model
                     break;
 
                 default:
-                    throw new ArgumentException($"Unsupported value: {style}", nameof(style));
+                    throw new ArgumentException($"Unsupported value: {options.EmphasisStyle}", nameof(options.EmphasisStyle));
             }
 
             return $"{emphasisChar}{text}{emphasisChar}";
         }
+
+
+        internal override MdSpan DeepCopy() => new MdEmphasisSpan(Text.DeepCopy());       
     }
 }

--- a/src/MarkdownGenerator/main/Model/_Spans/MdImageSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdImageSpan.cs
@@ -56,9 +56,11 @@ namespace Grynwald.MarkdownGenerator.Model
         }
 
 
-        public override string ToString()
+        public override string ToString() => ToString(MdSerializationOptions.Default);
+  
+        public override string ToString(MdSerializationOptions options)
         {
-            var description = Description.ToString();
+            var description = Description.ToString(options);
             var uri = Uri.ToString();
 
             if (String.IsNullOrEmpty(description) && String.IsNullOrEmpty(uri))
@@ -70,9 +72,6 @@ namespace Grynwald.MarkdownGenerator.Model
                 return $"![{description}]({uri})";
             }
         }
-
-        public override string ToString(MdSerializationOptions options) => ToString();
-
 
         internal override MdSpan DeepCopy() => new MdImageSpan(Description.DeepCopy(), Uri);
     }

--- a/src/MarkdownGenerator/main/Model/_Spans/MdLinkSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdLinkSpan.cs
@@ -56,9 +56,11 @@ namespace Grynwald.MarkdownGenerator.Model
         }
 
 
-        public override string ToString()
+        public override string ToString() => ToString(MdSerializationOptions.Default);
+
+        public override string ToString(MdSerializationOptions options)
         {
-            var text = Text.ToString();
+            var text = Text.ToString(options);
             var uri = Uri.ToString();
 
             if (String.IsNullOrEmpty(text) && String.IsNullOrEmpty(uri))
@@ -68,10 +70,8 @@ namespace Grynwald.MarkdownGenerator.Model
             else
             {
                 return $"[{text}]({uri})";
-            }            
+            }
         }
-
-        public override string ToString(MdSerializationOptions options) => ToString();
 
 
         internal override MdSpan DeepCopy() => new MdLinkSpan(Text.DeepCopy(), Uri);

--- a/src/MarkdownGenerator/main/Model/_Spans/MdSingleLineSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdSingleLineSpan.cs
@@ -23,9 +23,11 @@ namespace Grynwald.MarkdownGenerator.Model
             Content = content ?? throw new ArgumentNullException(nameof(content));
 
 
-        public override string ToString()
+        public override string ToString() => ToString(MdSerializationOptions.Default);
+
+        public override string ToString(MdSerializationOptions options)
         {
-            var content = Content.ToString();
+            var content = Content.ToString(options);
 
             // remove trailing line breaks
             content = s_TrailingLineBreakRegex.Replace(content, "");
@@ -38,9 +40,6 @@ namespace Grynwald.MarkdownGenerator.Model
 
             return content;
         }
-
-        public override string ToString(MdSerializationOptions options) => ToString();
-
 
         internal override MdSpan DeepCopy() => new MdSingleLineSpan(Content.DeepCopy());
     }

--- a/src/MarkdownGenerator/main/Model/_Spans/MdStrongEmphasisSpan.cs
+++ b/src/MarkdownGenerator/main/Model/_Spans/MdStrongEmphasisSpan.cs
@@ -28,17 +28,11 @@ namespace Grynwald.MarkdownGenerator.Model
             Text = text ?? throw new ArgumentNullException(nameof(text));
 
 
-        public override string ToString() => ToString(MdEmphasisStyle.Asterisk);
+        public override string ToString() => ToString(MdSerializationOptions.Default);
 
-        public override string ToString(MdSerializationOptions options) => ToString(options.EmphasisStyle);
-
-
-        internal override MdSpan DeepCopy() => new MdStrongEmphasisSpan(Text.DeepCopy());
-
-
-        private string ToString(MdEmphasisStyle style)
+        public override string ToString(MdSerializationOptions options)
         {
-            var text = Text.ToString();
+            var text = Text.ToString(options);
 
             if (String.IsNullOrEmpty(text))
             {
@@ -46,7 +40,7 @@ namespace Grynwald.MarkdownGenerator.Model
             }
 
             char emphasisChar;
-            switch (style)
+            switch (options.EmphasisStyle)
             {
                 case MdEmphasisStyle.Asterisk:
                     emphasisChar = '*';
@@ -56,10 +50,12 @@ namespace Grynwald.MarkdownGenerator.Model
                     break;
 
                 default:
-                    throw new ArgumentException($"Unsupported value: {style}", nameof(style));
+                    throw new ArgumentException($"Unsupported value: {options.EmphasisStyle}", nameof(options.EmphasisStyle));
             }
 
             return $"{emphasisChar}{emphasisChar}{text}{emphasisChar}{emphasisChar}";
         }
+
+        internal override MdSpan DeepCopy() => new MdStrongEmphasisSpan(Text.DeepCopy());       
     }
 }

--- a/src/MarkdownGenerator/main/Utilities/BlockQuotePrefixHandler.cs
+++ b/src/MarkdownGenerator/main/Utilities/BlockQuotePrefixHandler.cs
@@ -10,6 +10,8 @@
         // do no prefix blank lines before the quote, then prefix all lines
         public string GetBlankLinePrefix() => m_LineWritten ? "> " : "";
 
+        public string PreviewLinePrefix() => "> ";
+
         public string GetLinePrefix()
         {
             m_LineWritten = true;

--- a/src/MarkdownGenerator/main/Utilities/DocumentSerializer.cs
+++ b/src/MarkdownGenerator/main/Utilities/DocumentSerializer.cs
@@ -101,11 +101,25 @@ namespace Grynwald.MarkdownGenerator.Utilities
             
             if(m_Options.HeadingStyle == MdHeadingStyle.Setex && block.Level <= 2)
             {
-                var headingText = block.Text.ToString(m_Options);
-                m_Writer.WriteLine(headingText);
-
                 var underlineChar = block.Level == 1 ? '=' : '-';
-                m_Writer.WriteLine(new String(underlineChar, headingText.Length));
+                var text = block.Text.ToString(m_Options);
+
+                // if no maximum line length was specified, write heading into a single line
+                if(m_Options.MaxLineLength <= 0)
+                {
+                    m_Writer.WriteLine(text);
+                    m_Writer.WriteLine(new String(underlineChar, text.Length));
+                }
+                // is max line length was specified, split the value into multiple lines if necessary
+                else
+                {
+                    var headingTextLines = LineFormatter.GetLines(text, m_Options.MaxLineLength - m_Writer.PrefixLength);
+                    foreach(var line in headingTextLines)
+                    {
+                        m_Writer.WriteLine(line);
+                    }
+                    m_Writer.WriteLine(new String(underlineChar, headingTextLines.Max(x => x.Length)));
+                }                
             }
             else
             {
@@ -358,7 +372,6 @@ namespace Grynwald.MarkdownGenerator.Utilities
                 default:
                     throw new ArgumentException($"Unsupported thematic break style: {m_Options.ThematicBreakStyle}");                    
             }            
-        }       
-        
+        }                     
     }
 }

--- a/src/MarkdownGenerator/main/Utilities/IPrefixHandler.cs
+++ b/src/MarkdownGenerator/main/Utilities/IPrefixHandler.cs
@@ -2,6 +2,8 @@
 {
     interface IPrefixHandler
     {
+        string PreviewLinePrefix();
+
         string GetLinePrefix();
 
         string GetBlankLinePrefix();

--- a/src/MarkdownGenerator/main/Utilities/LineFormatter.cs
+++ b/src/MarkdownGenerator/main/Utilities/LineFormatter.cs
@@ -106,46 +106,42 @@ namespace Grynwald.MarkdownGenerator.Utilities
 
         }
         
-        internal static IEnumerable<StringSegment> GetStringSegments(string input)
+        /// <summary>
+        /// Spltis the specified string into a sequence of segements.
+        /// Each segment is either a whitespace-segment (contains only whitespace characters)
+        /// or an non-whitespace segment
+        /// </summary>
+        internal static IReadOnlyList<StringSegment> GetStringSegments(string input)
         {
+            // empty string => no segements
             if(String.IsNullOrEmpty(input))
-            {
-                yield break;                
-            }
+                return Array.Empty<StringSegment>();
 
-            int i = 0;
+            var segments = new List<StringSegment>();
+
+            var i = 0;
             while (i < input.Length)
             {
-                if (char.IsWhiteSpace(input[i]))
-                {
-                    var start = i;
-                    while (i < input.Length && char.IsWhiteSpace(input[i]))
-                    {
-                        i++;
-                    }
-                    yield return new StringSegment()
-                    {
-                        Value = input.Substring(start, i - start),
-                        IsWhiteSpace = true
-                    };
-                }
-                else
-                {
-                    var start = i;
-                    while (i < input.Length && !char.IsWhiteSpace(input[i]))
-                    {
-                        i++;
-                    }
-                    yield return new StringSegment()
-                    {
-                        Value = input.Substring(start, i - start),
-                        IsWhiteSpace = false
-                    };
+                // determine is current char is whitespace or not
+                var isWhiteSpace = char.IsWhiteSpace(input[i]);
 
+                // move i forward as long as all chars are whitespace or non-whitespace
+                var start = i;
+                while (i < input.Length && char.IsWhiteSpace(input[i]) == isWhiteSpace)
+                {
+                    i++;
                 }
 
-            }            
+                // emit new segment
+                segments.Add(new StringSegment()
+                {
+                    Value = input.Substring(start, i - start),
+                    IsWhiteSpace = isWhiteSpace
+                });
 
+            }
+
+            return segments;
         }        
     }
 }

--- a/src/MarkdownGenerator/main/Utilities/LineFormatter.cs
+++ b/src/MarkdownGenerator/main/Utilities/LineFormatter.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Grynwald.MarkdownGenerator.Utilities
+{   
+    class LineFormatter 
+    {
+        internal struct StringSegment
+        {
+            public string Value { get; set; }
+
+            public int Length => Value.Length;
+
+            public bool IsWhiteSpace { get; set; }
+        }
+        
+
+        public static IEnumerable<string> GetLines(string input, int maxLineLength)
+        {
+            var segments = GetStringSegments(input).ToArray();
+
+            var stringBuilder = new StringBuilder();
+
+            for(int i = 0; i < segments.Length; i++)
+            {
+                var islast = i == segments.Length - 1;
+                                
+                if(islast)
+                {
+                    var currentSegment = segments[i];
+
+                    if(currentSegment.IsWhiteSpace)
+                    {
+                        if (stringBuilder.Length > 0)
+                            stringBuilder.Append(currentSegment.Value);
+                    }
+                    else
+                    {
+                        if (stringBuilder.Length + currentSegment.Length <= maxLineLength)
+                        {
+                            stringBuilder.Append(currentSegment.Value);
+                        }
+                        else
+                        {
+                            if(stringBuilder.Length > 0)
+                            {
+                                yield return stringBuilder.ToString();
+                            }
+
+                            stringBuilder = new StringBuilder();
+                            stringBuilder.Append(currentSegment.Value);
+                        }
+
+                    }
+                }
+                else
+                {
+                    var currentSegment = segments[i];
+                    var nextSegment = segments[i + 1];
+
+                    if(stringBuilder.Length == 0)
+                    {
+                        stringBuilder.Append(currentSegment.Value);
+                        continue;
+                    }
+
+
+                    if(currentSegment.IsWhiteSpace)
+                    {
+                        if (stringBuilder.Length + currentSegment.Length + nextSegment.Length <= maxLineLength)
+                        {
+                            stringBuilder.Append(currentSegment.Value);
+                            //stringBuilder.Append(nextSegment.Value);
+                        }
+                        else
+                        {
+                            yield return stringBuilder.ToString();
+                            stringBuilder = new StringBuilder();
+                        }
+                    }
+                    else
+                    {
+                        // append if it still fits within max length, otherwise being anew
+                        if(stringBuilder.Length + currentSegment.Length <= maxLineLength)
+                        {
+                            stringBuilder.Append(currentSegment.Value);
+                        }
+                        else
+                        {
+                            yield return stringBuilder.ToString();
+                            stringBuilder = new StringBuilder();
+                            stringBuilder.Append(currentSegment.Value);
+                        }
+                    }
+
+                }
+               
+            }
+
+
+            if (stringBuilder.Length > 0)
+                yield return stringBuilder.ToString().TrimEnd();
+
+        }
+        
+        internal static IEnumerable<StringSegment> GetStringSegments(string input)
+        {
+            if(String.IsNullOrEmpty(input))
+            {
+                yield break;                
+            }
+
+            int i = 0;
+            while (i < input.Length)
+            {
+                if (char.IsWhiteSpace(input[i]))
+                {
+                    var start = i;
+                    while (i < input.Length && char.IsWhiteSpace(input[i]))
+                    {
+                        i++;
+                    }
+                    yield return new StringSegment()
+                    {
+                        Value = input.Substring(start, i - start),
+                        IsWhiteSpace = true
+                    };
+                }
+                else
+                {
+                    var start = i;
+                    while (i < input.Length && !char.IsWhiteSpace(input[i]))
+                    {
+                        i++;
+                    }
+                    yield return new StringSegment()
+                    {
+                        Value = input.Substring(start, i - start),
+                        IsWhiteSpace = false
+                    };
+
+                }
+
+            }            
+
+        }        
+    }
+}

--- a/src/MarkdownGenerator/main/Utilities/LineFormatter.cs
+++ b/src/MarkdownGenerator/main/Utilities/LineFormatter.cs
@@ -8,6 +8,14 @@ namespace Grynwald.MarkdownGenerator.Utilities
     {
         public static IEnumerable<string> GetLines(string input, int maxLineLength)
         {
+            // fast path: if the input is already shorter than the maximum length
+            // return it unchanged
+            if(input.Length <= maxLineLength)
+            {
+                yield return input;
+                yield break;
+            }
+
             var segments = GetStringSegments(input).ToArray();
 
 

--- a/src/MarkdownGenerator/main/Utilities/LineFormatter.cs
+++ b/src/MarkdownGenerator/main/Utilities/LineFormatter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,16 +7,6 @@ namespace Grynwald.MarkdownGenerator.Utilities
 {   
     class LineFormatter 
     {
-        internal struct StringSegment
-        {
-            public string Value { get; set; }
-
-            public int Length => Value.Length;
-
-            public bool IsWhiteSpace { get; set; }
-        }
-        
-
         public static IEnumerable<string> GetLines(string input, int maxLineLength)
         {
             var segments = GetStringSegments(input).ToArray();
@@ -30,18 +19,18 @@ namespace Grynwald.MarkdownGenerator.Utilities
                                 
                 if(islast)
                 {
-                    var currentSegment = segments[i];
+                    var (value, isWhiteSpace) = segments[i];
 
-                    if(currentSegment.IsWhiteSpace)
+                    if(isWhiteSpace)
                     {
                         if (stringBuilder.Length > 0)
-                            stringBuilder.Append(currentSegment.Value);
+                            stringBuilder.Append(value);
                     }
                     else
                     {
-                        if (stringBuilder.Length + currentSegment.Length <= maxLineLength)
+                        if (stringBuilder.Length + value.Length <= maxLineLength)
                         {
-                            stringBuilder.Append(currentSegment.Value);
+                            stringBuilder.Append(value);
                         }
                         else
                         {
@@ -51,28 +40,28 @@ namespace Grynwald.MarkdownGenerator.Utilities
                             }
 
                             stringBuilder = new StringBuilder();
-                            stringBuilder.Append(currentSegment.Value);
+                            stringBuilder.Append(value);
                         }
 
                     }
                 }
                 else
                 {
-                    var currentSegment = segments[i];
-                    var nextSegment = segments[i + 1];
+                    var (currentValue, currentIsWhiteSpace) = segments[i];
+                    var (nextValue, nextIsWhiteSpace) = segments[i + 1];
 
                     if(stringBuilder.Length == 0)
                     {
-                        stringBuilder.Append(currentSegment.Value);
+                        stringBuilder.Append(currentValue);
                         continue;
                     }
 
 
-                    if(currentSegment.IsWhiteSpace)
+                    if(currentIsWhiteSpace)
                     {
-                        if (stringBuilder.Length + currentSegment.Length + nextSegment.Length <= maxLineLength)
+                        if (stringBuilder.Length + currentValue.Length + nextValue.Length <= maxLineLength)
                         {
-                            stringBuilder.Append(currentSegment.Value);
+                            stringBuilder.Append(currentValue);
                             //stringBuilder.Append(nextSegment.Value);
                         }
                         else
@@ -84,15 +73,15 @@ namespace Grynwald.MarkdownGenerator.Utilities
                     else
                     {
                         // append if it still fits within max length, otherwise being anew
-                        if(stringBuilder.Length + currentSegment.Length <= maxLineLength)
+                        if(stringBuilder.Length + currentValue.Length <= maxLineLength)
                         {
-                            stringBuilder.Append(currentSegment.Value);
+                            stringBuilder.Append(currentValue);
                         }
                         else
                         {
                             yield return stringBuilder.ToString();
                             stringBuilder = new StringBuilder();
-                            stringBuilder.Append(currentSegment.Value);
+                            stringBuilder.Append(currentValue);
                         }
                     }
 
@@ -107,17 +96,17 @@ namespace Grynwald.MarkdownGenerator.Utilities
         }
         
         /// <summary>
-        /// Spltis the specified string into a sequence of segements.
+        /// Splits the specified string into a sequence of segments.
         /// Each segment is either a whitespace-segment (contains only whitespace characters)
         /// or an non-whitespace segment
         /// </summary>
-        internal static IReadOnlyList<StringSegment> GetStringSegments(string input)
+        internal static IReadOnlyList<(string value, bool isWhiteSpace)> GetStringSegments(string input)
         {
             // empty string => no segements
             if(String.IsNullOrEmpty(input))
-                return Array.Empty<StringSegment>();
+                return Array.Empty<(string, bool)>();
 
-            var segments = new List<StringSegment>();
+            var segments = new List<(string, bool)>();
 
             var i = 0;
             while (i < input.Length)
@@ -133,12 +122,7 @@ namespace Grynwald.MarkdownGenerator.Utilities
                 }
 
                 // emit new segment
-                segments.Add(new StringSegment()
-                {
-                    Value = input.Substring(start, i - start),
-                    IsWhiteSpace = isWhiteSpace
-                });
-
+                segments.Add((input.Substring(start, i - start), isWhiteSpace));
             }
 
             return segments;

--- a/src/MarkdownGenerator/main/Utilities/ListPrefixHandler.cs
+++ b/src/MarkdownGenerator/main/Utilities/ListPrefixHandler.cs
@@ -29,6 +29,18 @@ namespace Grynwald.MarkdownGenerator.Utilities
             }
         }
 
+        public string PreviewLinePrefix()
+        {
+            if (m_LineWritten)
+            {
+                return m_ListPrefix;
+            }
+            else
+            {             
+                return m_ListMarker;
+            }
+        }
+
 
         public virtual void BeginListItem()
         {

--- a/src/MarkdownGenerator/main/Utilities/PrefixTextWriter.cs
+++ b/src/MarkdownGenerator/main/Utilities/PrefixTextWriter.cs
@@ -17,6 +17,8 @@ namespace Grynwald.MarkdownGenerator.Utilities
 
         public event EventHandler<EventArgs> BlankLineRequested;
 
+        public int PrefixLength => PreviewLinePrefix().Length;
+
         
         public PrefixTextWriter(TextWriter innerWriter)
         {
@@ -83,6 +85,17 @@ namespace Grynwald.MarkdownGenerator.Utilities
             foreach (var handler in m_PrefixHandlers)
             {
                 prefixBuilder.Append(handler.GetLinePrefix());
+            }
+            return prefixBuilder.ToString();
+        }
+
+
+        private string PreviewLinePrefix()
+        {
+            var prefixBuilder = new StringBuilder();
+            foreach (var handler in m_PrefixHandlers)
+            {
+                prefixBuilder.Append(handler.PreviewLinePrefix());
             }
             return prefixBuilder.ToString();
         }

--- a/src/MarkdownGenerator/main/Utilities/ResettableStringBuilder.cs
+++ b/src/MarkdownGenerator/main/Utilities/ResettableStringBuilder.cs
@@ -1,0 +1,29 @@
+﻿using System.Text;
+
+namespace Grynwald.MarkdownGenerator.Utilities
+{
+    internal class ResettableStringBuilder
+    {
+        private StringBuilder m_StringBuilder = new StringBuilder();
+
+
+        public int Length => m_StringBuilder.Length;
+
+        public bool IsEmpty => Length == 0;
+
+
+        public void Reset() => m_StringBuilder = new StringBuilder();
+
+        public string GetAndReset()
+        {
+            var value = m_StringBuilder.ToString();
+            Reset();
+            return value;
+        }
+
+        public void Append(string value) => m_StringBuilder.Append(value);
+
+        public override string ToString() => m_StringBuilder.ToString();
+
+    }    
+}

--- a/src/MarkdownGenerator/test/Grynwald.MarkdownGenerator.Test.csproj
+++ b/src/MarkdownGenerator/test/Grynwald.MarkdownGenerator.Test.csproj
@@ -7,6 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Grynwald.Utilities" Version="1.1.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
 		<PackageReference Include="xunit" Version="2.3.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/src/MarkdownGenerator/test/Model/_Blocks/MdHeadingTest.cs
+++ b/src/MarkdownGenerator/test/Model/_Blocks/MdHeadingTest.cs
@@ -17,9 +17,9 @@ namespace Grynwald.MarkdownGenerator.Test.Model
                 ? FactoryMethods.Heading("Content", 1)
                 : new MdHeading("Content", 1);
             
-            Assert.IsType<MdTextSpan>(heading.Text);
+            Assert.IsType<MdTextSpan>(heading.Text.Content);
             
-            var textSpan = (MdTextSpan)heading.Text;
+            var textSpan = (MdTextSpan)heading.Text.Content;
             Assert.Equal("Content", textSpan.Text);
         }
 
@@ -32,9 +32,9 @@ namespace Grynwald.MarkdownGenerator.Test.Model
                 ? FactoryMethods.Heading(1, "Content")
                 : new MdHeading(1, "Content");
 
-            Assert.IsType<MdTextSpan>(heading.Text);
+            Assert.IsType<MdTextSpan>(heading.Text.Content);
 
-            var textSpan = (MdTextSpan)heading.Text;
+            var textSpan = (MdTextSpan)heading.Text.Content;
             Assert.Equal("Content", textSpan.Text);
         }
 
@@ -47,8 +47,8 @@ namespace Grynwald.MarkdownGenerator.Test.Model
                 ? FactoryMethods.Heading(1, "Content1", "Content2")
                 : new MdHeading(1, "Content1", "Content2");
 
-            Assert.IsType<MdCompositeSpan>(heading.Text);
-            var compositeSpan = (MdCompositeSpan)heading.Text;
+            Assert.IsType<MdCompositeSpan>(heading.Text.Content);
+            var compositeSpan = (MdCompositeSpan)heading.Text.Content;
 
             Assert.IsType<MdTextSpan>(compositeSpan.Spans[0]);
             Assert.IsType<MdTextSpan>(compositeSpan.Spans[1]);
@@ -70,8 +70,8 @@ namespace Grynwald.MarkdownGenerator.Test.Model
             var heading = useFactoryMethods
                 ? FactoryMethods.Heading(text, 1)
                 : new MdHeading(text, 1);
-
-            Assert.Same(text, heading.Text);
+            
+            Assert.Same(text, heading.Text.Content);
         }      
     }
 }

--- a/src/MarkdownGenerator/test/Utilities/DocumentSerializerTest.cs
+++ b/src/MarkdownGenerator/test/Utilities/DocumentSerializerTest.cs
@@ -667,6 +667,57 @@ namespace Grynwald.MarkdownGenerator.Test.Model
             );
         }
 
+        [Fact]
+        public void Setex_headings_are_formatted_to_the_maximum_line_length_01()
+        {
+            var options = new MdSerializationOptions()
+            {
+                MaxLineLength = 10,
+                HeadingStyle = MdHeadingStyle.Setex
+            };
+
+            AssertToStringEquals("Heading,\r\n" +
+                "heading\r\n" +
+                "part 2\r\n" +
+                "========\r\n",
+                Document(Heading(1, "Heading, heading part 2")),
+                options
+            );
+        }
+
+        [Fact]
+        public void Setex_headings_are_formatted_to_the_maximum_line_length_02()
+        {
+            var options = new MdSerializationOptions()
+            {
+                MaxLineLength = 5,
+                HeadingStyle = MdHeadingStyle.Setex
+            };
+
+            AssertToStringEquals("Heading\r\n" +
+                "heading\r\n" +
+                "=======\r\n",
+                Document(Heading(1, "Heading  heading")),
+                options
+            );
+        }
+
+        [Fact]
+        public void Setex_headings_are_formatted_to_the_maximum_line_length_03()
+        {
+            var options = new MdSerializationOptions()
+            {
+                MaxLineLength = 20,
+                HeadingStyle = MdHeadingStyle.Setex
+            };
+
+            AssertToStringEquals(
+                "Heading 1\r\n" +
+                "=========\r\n",
+                Document(Heading(1, "Heading 1")),
+                options
+            );
+        }
 
 
         private void AssertToStringEquals(string expected, MdDocument document, MdSerializationOptions options = null)

--- a/src/MarkdownGenerator/test/Utilities/DocumentSerializerTest.cs
+++ b/src/MarkdownGenerator/test/Utilities/DocumentSerializerTest.cs
@@ -720,6 +720,87 @@ namespace Grynwald.MarkdownGenerator.Test.Model
         }
 
 
+        [Fact]
+        public void Paragraphs_are_formatted_to_the_maximum_line_length_01()
+        {
+            var options = new MdSerializationOptions()
+            {
+                MaxLineLength = 5
+            };
+
+            AssertToStringEquals(
+               "aaaaaaaa\r\n" +
+               "bbbb\r\n",
+               Document(
+                   Paragraph("aaaaaaaa bbbb")
+                ),
+               options
+           );
+
+        }
+
+
+        [Fact]
+        public void Paragraphs_are_formatted_to_the_maximum_line_length_02()
+        {
+            var options = new MdSerializationOptions()
+            {
+                MaxLineLength = 5
+            };
+
+            AssertToStringEquals(
+               "aaaaaaaa\r\n" +
+               "bbbb  \r\n" +
+               "cccc\r\n",
+               Document(
+                   Paragraph("aaaaaaaa bbbb\r\ncccc")
+                ),
+               options
+           );
+        }
+
+
+        [Fact]
+        public void Paragraphs_in_lists_are_formatted_to_the_maximum_line_length()
+        {
+            var options = new MdSerializationOptions()
+            {
+                MaxLineLength = 5
+            };
+
+            AssertToStringEquals(
+               "- aaaaaaaa\r\n" +
+               "  bb\r\n" +
+               "  cc\r\n",
+               Document(
+                   BulletList(ListItem(Paragraph("aaaaaaaa bb cc")))
+                ),
+               options
+           );
+
+        }
+
+        [Fact]
+        public void Paragraphs_in_block_quotes_are_formatted_to_the_maximum_line_length()
+        {
+            var options = new MdSerializationOptions()
+            {
+                MaxLineLength = 5
+            };
+
+            AssertToStringEquals(
+               "> aaaaaaaa\r\n" +
+               "> bb\r\n" +
+               "> cc\r\n",
+               Document(
+                   BlockQuote(Paragraph("aaaaaaaa bb cc"))
+                ),
+               options
+           );
+        }
+
+
+
         private void AssertToStringEquals(string expected, MdDocument document, MdSerializationOptions options = null)
         {            
             using (var writer = new StringWriter())

--- a/src/MarkdownGenerator/test/Utilities/LineFormatterTest.cs
+++ b/src/MarkdownGenerator/test/Utilities/LineFormatterTest.cs
@@ -40,7 +40,7 @@ namespace Grynwald.MarkdownGenerator.Test.Utilities
         [InlineData("", new string[0])]        
         public void GetStringSegments_returns_the_expected_segments(string input, string[] expectedSegments)
         {
-            var actualSegments = LineFormatter.GetStringSegments(input).Select(x => x.Value).ToArray();
+            var actualSegments = LineFormatter.GetStringSegments(input).Select(x => x.value).ToArray();
             if (!expectedSegments.SequenceEqual(actualSegments))
             {
                 throw new XunitException("SequenceEqual failure:\r\n" +

--- a/src/MarkdownGenerator/test/Utilities/LineFormatterTest.cs
+++ b/src/MarkdownGenerator/test/Utilities/LineFormatterTest.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Linq;
+using Grynwald.MarkdownGenerator.Utilities;
+using Grynwald.Utilities.Collections;
+using Xunit;
+using Xunit.Sdk;
+
+
+namespace Grynwald.MarkdownGenerator.Test.Utilities
+{
+    public class LineFormatterTest
+    {
+        [Theory]
+        [InlineData(5, "abcde", new [] {  "abcde" })]
+        [InlineData(5, "abcde fgh", new [] {  "abcde", "fgh" })]
+        [InlineData(5, "ab de fgh", new [] {  "ab de", "fgh" })]
+        [InlineData(5, "abcdefgh", new [] {  "abcdefgh" })]
+        [InlineData(5, "abcdefgh ijk", new [] {  "abcdefgh", "ijk" })]        
+        [InlineData(5, "abc defgh ijk", new [] {  "abc", "defgh", "ijk" })]        
+        [InlineData(5, "abc def  ijk", new [] {  "abc", "def",  "ijk" })]        
+        public void Line_is_split_as_expected(int lineLength, string input, string[] expectedResult)
+        {
+            var actualResult = LineFormatter.GetLines(input, lineLength);
+
+            if(!expectedResult.SequenceEqual(actualResult))
+            {
+                throw new XunitException("SequenceEqual failure:\r\n" +
+                    $"Expected: {expectedResult.Select(x=> $"\"{x}\"").JoinToString(", ")}\r\n" +
+                    $"Actual:   {actualResult.Select(x => $"\"{x}\"").JoinToString(", ")}");
+            }            
+        }
+        
+        [Theory]
+        [InlineData("abcde", new[] { "abcde" })]
+        [InlineData("abcde fgh", new[] { "abcde", " ", "fgh" })]
+        [InlineData("ab  de fgh", new[] { "ab", "  ", "de", " ", "fgh" })]
+        [InlineData("  abc", new[] {"  ", "abc" })]        
+        [InlineData("abc  ", new[] {"abc", "  " })]        
+        [InlineData("  abc  ", new[] {"  ", "abc", "  " })]        
+        public void GetStringSegments_returns_the_expected_segments(string input, string[] expectedSegments)
+        {
+            var actualSegments = LineFormatter.GetStringSegments(input).Select(x => x.Value).ToArray();
+            if (!expectedSegments.SequenceEqual(actualSegments))
+            {
+                throw new XunitException("SequenceEqual failure:\r\n" +
+                    $"Expected: {expectedSegments.Select(x => $"\"{x}\"").JoinToString(", ")}\r\n" +
+                    $"Actual:   {actualSegments.Select(x => $"\"{x}\"").JoinToString(", ")}");
+            }
+        }
+
+    }
+}

--- a/src/MarkdownGenerator/test/Utilities/LineFormatterTest.cs
+++ b/src/MarkdownGenerator/test/Utilities/LineFormatterTest.cs
@@ -37,6 +37,7 @@ namespace Grynwald.MarkdownGenerator.Test.Utilities
         [InlineData("  abc", new[] {"  ", "abc" })]        
         [InlineData("abc  ", new[] {"abc", "  " })]        
         [InlineData("  abc  ", new[] {"  ", "abc", "  " })]        
+        [InlineData("", new string[0])]        
         public void GetStringSegments_returns_the_expected_segments(string input, string[] expectedSegments)
         {
             var actualSegments = LineFormatter.GetStringSegments(input).Select(x => x.Value).ToArray();

--- a/src/MarkdownGenerator/test/Utilities/LineFormatterTest.cs
+++ b/src/MarkdownGenerator/test/Utilities/LineFormatterTest.cs
@@ -18,6 +18,7 @@ namespace Grynwald.MarkdownGenerator.Test.Utilities
         [InlineData(5, "abcdefgh ijk", new [] {  "abcdefgh", "ijk" })]        
         [InlineData(5, "abc defgh ijk", new [] {  "abc", "defgh", "ijk" })]        
         [InlineData(5, "abc def  ijk", new [] {  "abc", "def",  "ijk" })]        
+        [InlineData(80, "abc def ijk", new [] { "abc def ijk" })]        
         public void Line_is_split_as_expected(int lineLength, string input, string[] expectedResult)
         {
             var actualResult = LineFormatter.GetLines(input, lineLength);


### PR DESCRIPTION
Allows specifying a maximum line length as part of serialization options. When a maximum length is specified, the output will be re-formatted accordingly, when possible.