### PR TITLE
Add "Admonition" block

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,10 @@ well as the *table* extension specified by
 
 - For an overview of the library's API, see [API](./api/README.md)
 - For usage examples see [Examples](./examples/README.md)
+
+Aside from CommonMark elements, the `Grynwald.MarkdownGenerator.Extensions`
+namespace provides additional elements not supported by most Markdown renderers.
+**Use with caution**.
+
+The extensions currently provides support for the
+["Admonitions" extension for Python Markdown](https://python-markdown.github.io/extensions/admonition/) using the `MdAdmonition` type.

--- a/docs/api/block-types.md
+++ b/docs/api/block-types.md
@@ -39,3 +39,13 @@ There are two types of lists:
 
 - `MdBulletList`: Represents a bullet list
 - `MdOrderedList`: Represents a ordered list
+
+## Extension blocks
+
+The namespace `Grynwald.MarkdownGenerator.Extensions` provides additional
+block types that implement elements supported by most Markdown renderers.
+**Use with caution**.
+
+- `MdAdmonition`: Adds support for emitting *admonitions* for use with
+  the ["Admonitions" extension for Python Markdown](https://python-markdown.github.io/extensions/admonition/).
+  

--- a/src/MarkdownGenerator.Test/Internal/_DocumentSerializer/DocumentSerializerTest.Extensions.cs
+++ b/src/MarkdownGenerator.Test/Internal/_DocumentSerializer/DocumentSerializerTest.Extensions.cs
@@ -1,0 +1,46 @@
+﻿using Grynwald.MarkdownGenerator.Extensions;
+using Xunit;
+using static Grynwald.MarkdownGenerator.Extensions.FactoryMethods;
+using static Grynwald.MarkdownGenerator.FactoryMethods;
+
+namespace Grynwald.MarkdownGenerator.Test.Internal
+{
+    public partial class DocumentSerializerTest
+    {
+        [Fact]
+        public void Admonitions_are_serialized_as_expected_01()
+        {            
+            AssertToStringEquals(
+                "# Heading\r\n" +
+                "\r\n" +
+                "!!! note\r\n" +
+                "    Note content\r\n",
+
+                Document(
+                    Heading(1, "Heading"),
+                    Admonition(
+                        "Note",
+                        Paragraph("Note content")))
+            );
+        }
+
+        [Fact]
+        public void Admonitions_are_serialized_as_expected_02()
+        {
+            AssertToStringEquals(
+                "# Heading\r\n" +
+                "\r\n" +
+                "!!! note \"Note title\"\r\n" +
+                "    Note content\r\n",
+
+                Document(
+                    Heading(1, "Heading"),
+                    Admonition(
+                        "note",
+                        "Note title",
+                        Paragraph("Note content")))
+            );
+        }
+    }
+
+}

--- a/src/MarkdownGenerator.Test/Internal/_DocumentSerializer/DocumentSerializerTest.Extensions.cs
+++ b/src/MarkdownGenerator.Test/Internal/_DocumentSerializer/DocumentSerializerTest.Extensions.cs
@@ -9,6 +9,20 @@ namespace Grynwald.MarkdownGenerator.Test.Internal
     {
         [Fact]
         public void Admonitions_are_serialized_as_expected_01()
+        {
+            AssertToStringEquals(
+                "!!! note\r\n" +
+                "    Note content\r\n",
+
+                Document(
+                    Admonition(
+                        "Note",
+                        Paragraph("Note content")))
+            );
+        }
+
+        [Fact]
+        public void Admonitions_are_serialized_as_expected_02()
         {            
             AssertToStringEquals(
                 "# Heading\r\n" +
@@ -25,7 +39,7 @@ namespace Grynwald.MarkdownGenerator.Test.Internal
         }
 
         [Fact]
-        public void Admonitions_are_serialized_as_expected_02()
+        public void Admonitions_are_serialized_as_expected_03()
         {
             AssertToStringEquals(
                 "# Heading\r\n" +

--- a/src/MarkdownGenerator.Test/Internal/_DocumentSerializer/DocumentSerializerTest.cs
+++ b/src/MarkdownGenerator.Test/Internal/_DocumentSerializer/DocumentSerializerTest.cs
@@ -8,7 +8,7 @@ using static Grynwald.MarkdownGenerator.FactoryMethods;
 
 namespace Grynwald.MarkdownGenerator.Test.Internal
 {
-    public class DocumentSerializerTest
+    public partial class DocumentSerializerTest
     {
         [Fact]
         public void Headings_are_serialized_as_expected() =>

--- a/src/MarkdownGenerator.Test/_Model/AmbiguityTests.cs
+++ b/src/MarkdownGenerator.Test/_Model/AmbiguityTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Grynwald.MarkdownGenerator.Extensions;
 
 namespace Grynwald.MarkdownGenerator.Test
 {
@@ -19,6 +20,44 @@ namespace Grynwald.MarkdownGenerator.Test
     /// </remarks>
     public class AmbiguityTests
     {
+        public void Initialization_of_MdDocument_using_constructor()
+        {
+            _ = new MdDocument();
+
+            _ = new MdDocument(new MdContainerBlock());
+            _ = new MdDocument(new MdContainerBlock(), new MdContainerBlock());
+
+            _ = new MdDocument(new MdListItem(), new MdListItem());
+
+            _ = new MdDocument(new MdBlockQuote());
+            _ = new MdDocument(new MdBlockQuote(), new MdBlockQuote());
+
+            _ = new MdDocument(new MdBulletList());
+            _ = new MdDocument(new MdOrderedList());
+
+            _ = new MdDocument(new MdAdmonition("note"));
+            _ = new MdDocument(new MdAdmonition("note"), new MdAdmonition("note"));
+        }
+
+        public void Initialization_of_MdDocument_using_FactoryMethods()
+        {
+            _ = FactoryMethods.Document();
+
+            _ = FactoryMethods.Document(FactoryMethods.Container());
+            _ = FactoryMethods.Document(FactoryMethods.Container(), FactoryMethods.Container());
+            
+            _ = FactoryMethods.Document(FactoryMethods.ListItem(), FactoryMethods.ListItem());
+
+            _ = FactoryMethods.Document(FactoryMethods.BlockQuote());
+            _ = FactoryMethods.Document(FactoryMethods.BlockQuote(), FactoryMethods.BlockQuote());
+
+            _ = FactoryMethods.Document(FactoryMethods.BulletList());
+            _ = FactoryMethods.Document(FactoryMethods.OrderedList());
+
+            _ = FactoryMethods.Document(Extensions.FactoryMethods.Admonition("note"));
+        }
+
+
         public void Initialization_of_MdListItem_using_constructor()
         {
             _ = new MdListItem();
@@ -34,6 +73,8 @@ namespace Grynwald.MarkdownGenerator.Test
 
             _ = new MdListItem(new MdBulletList());
             _ = new MdListItem(new MdOrderedList());
+
+            _ = new MdListItem(new MdAdmonition("note"));
         }
 
         public void Initialization_of_MdListItem_using_FactoryMethods()
@@ -51,6 +92,8 @@ namespace Grynwald.MarkdownGenerator.Test
 
             _ = FactoryMethods.ListItem(FactoryMethods.BulletList());
             _ = FactoryMethods.ListItem(FactoryMethods.OrderedList());
+
+            _ = FactoryMethods.ListItem(Extensions.FactoryMethods.Admonition("note"));
         }
 
 
@@ -69,6 +112,9 @@ namespace Grynwald.MarkdownGenerator.Test
 
             _ = new MdContainerBlock(new MdBulletList());
             _ = new MdContainerBlock(new MdOrderedList());
+
+            _ = new MdContainerBlock(new MdAdmonition("note"));
+            _ = new MdContainerBlock(new MdAdmonition("note"), new MdAdmonition("note"));
         }
 
         public void Initialization_of_MdContainerBlock_using_FactoryMethods()
@@ -86,6 +132,8 @@ namespace Grynwald.MarkdownGenerator.Test
 
             _ = FactoryMethods.Container(FactoryMethods.BulletList());
             _ = FactoryMethods.Container(FactoryMethods.OrderedList());
+
+            _ = FactoryMethods.Container(Extensions.FactoryMethods.Admonition("note"));
         }
 
 
@@ -104,6 +152,8 @@ namespace Grynwald.MarkdownGenerator.Test
 
             _ = new MdBlockQuote(new MdBulletList());
             _ = new MdBlockQuote(new MdOrderedList());
+
+            _ = new MdBlockQuote(new MdAdmonition("note"));
         }
 
         public void Initialization_of_MdBlockQuote_using_FactoryMethods()
@@ -121,6 +171,8 @@ namespace Grynwald.MarkdownGenerator.Test
 
             _ = FactoryMethods.BlockQuote(FactoryMethods.BulletList());
             _ = FactoryMethods.BlockQuote(FactoryMethods.OrderedList());
+
+            _ = FactoryMethods.BlockQuote(Extensions.FactoryMethods.Admonition("note"));
         }
 
 

--- a/src/MarkdownGenerator/Extensions/FactoryMethods.cs
+++ b/src/MarkdownGenerator/Extensions/FactoryMethods.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+
+namespace Grynwald.MarkdownGenerator.Extensions
+{
+    public static class FactoryMethods
+    {
+        public static MdAdmonition Admonition(string type) => new MdAdmonition(type);
+
+        public static MdAdmonition Admonition(string type, MdSpan title) => new MdAdmonition(type, title);
+
+        public static MdAdmonition Admonition(string type, MdContainerBlockBase content) => new MdAdmonition(type, content);
+
+        public static MdAdmonition Admonition(string type, MdSpan title, MdContainerBlockBase content) => new MdAdmonition(type, title, content);
+
+        public static MdAdmonition Admonition(string type, MdList content) => new MdAdmonition(type, content);
+
+        public static MdAdmonition Admonition(string type, MdSpan title, MdList content) => new MdAdmonition(type, title, content);
+
+        public static MdAdmonition Admonition(string type, params MdBlock[] content) => new MdAdmonition(type, content);
+
+        public static MdAdmonition Admonition(string type, MdSpan title, params MdBlock[] content) => new MdAdmonition(type, title, content);
+
+        public static MdAdmonition Admonition(string type, IEnumerable<MdBlock> content) => new MdAdmonition(type, content);
+
+        public static MdAdmonition Admonition(string type, MdSpan title, IEnumerable<MdBlock> content) => new MdAdmonition(type, title, content);
+    }
+}

--- a/src/MarkdownGenerator/Extensions/_Admonition/MdAdmonition.cs
+++ b/src/MarkdownGenerator/Extensions/_Admonition/MdAdmonition.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using System.Collections.Generic;
+using Grynwald.MarkdownGenerator.Internal;
+
+namespace Grynwald.MarkdownGenerator.Extensions
+{
+    /// <summary>
+    /// Represents a "admonition" in a markdown document implemented by
+    /// the "Admonition" extension for Python-Markdown.
+    /// For details https://python-markdown.github.io/extensions/admonition/
+    /// </summary>
+    /// <remarks>
+    /// Using this element will produce markdown which will not be rendered correctly
+    /// by most Markdown implementation and should only be used, when the renderer
+    /// is known to be Python Markdown with the Admonition extension enabled.
+    /// </remarks>
+    public class MdAdmonition : MdContainerBlockBase
+    {
+        /// <summary>
+        /// Get the admonition's type.
+        /// </summary>
+        /// <value>The admonition's type as specified when the instance was initialized.</value>
+        public string Type { get; }
+
+        /// <summary>
+        /// Gets the admonition's (optional) title
+        /// </summary>
+        /// <value>The admonition's title as specified when the instance was initialized. Value is guaranteed to be not <c>null</c>.</value>
+        public MdSpan Title { get; }
+
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MdAdmonition"/> without content.
+        /// </summary>
+        ///
+        /// <param name="type">
+        /// The admonition's type. Any non-empty string is allowed.
+        /// Recommended values are <c>attention</c>, <c>caution</c>, <c>danger</c>, <c>error</c>,
+        /// <c>hint</c>, <c>important</c>, <c>note</c>, <c>tip</c> and <c>warning</c>
+        /// </param>
+        /// 
+        /// <exception cref="ArgumentException">Thrown when <paramref name="type"/> is null or whitespace.</exception>
+        public MdAdmonition(string type) : this(type, MdEmptySpan.Instance, Array.Empty<MdBlock>())
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MdAdmonition"/> with the specified type and title but without any content.
+        /// </summary>
+        /// 
+        /// <param name="type">
+        /// The admonition's type. Any non-empty string is allowed.
+        /// Recommended values are <c>attention</c>, <c>caution</c>, <c>danger</c>, <c>error</c>,
+        /// <c>hint</c>, <c>important</c>, <c>note</c>, <c>tip</c> and <c>warning</c>
+        /// </param>
+        ///
+        /// <param name="title">
+        /// The admonition's title. To create a admonition without title, use a different constructor overload.
+        /// </param>
+        ///
+        /// <exception cref="ArgumentException">Thrown when <paramref name="type"/> is null or whitespace.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="title"/> is <c>null</c>.</exception>
+        public MdAdmonition(string type, MdSpan title) : this(type, title, Array.Empty<MdBlock>())
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MdAdmonition"/> with the specified type and content.
+        /// </summary>
+        /// 
+        /// <param name="type">
+        /// The admonition's type. Any non-empty string is allowed.
+        /// Recommended values are <c>attention</c>, <c>caution</c>, <c>danger</c>, <c>error</c>,
+        /// <c>hint</c>, <c>important</c>, <c>note</c>, <c>tip</c> and <c>warning</c>
+        /// </param>
+        ///
+        /// <param name="content">
+        /// The admonition's content.
+        /// </param>
+        ///
+        /// <exception cref="ArgumentException">Thrown when <paramref name="type"/> is null or whitespace.</exception>
+        public MdAdmonition(string type, MdContainerBlockBase content) : this(type, MdEmptySpan.Instance, (MdBlock)content)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MdAdmonition"/>.
+        /// </summary>
+        ///
+        /// <param name="type">
+        /// The admonition's type. Any non-empty string is allowed.
+        /// Recommended values are <c>attention</c>, <c>caution</c>, <c>danger</c>, <c>error</c>,
+        /// <c>hint</c>, <c>important</c>, <c>note</c>, <c>tip</c> and <c>warning</c>
+        /// </param>
+        ///
+        /// <param name="title">
+        /// The admonition's title. To create a admonition without title, use a different constructor overload.
+        /// </param>
+        ///
+        /// <param name="content">
+        /// The admonition's content.
+        /// </param>
+        /// 
+        /// <exception cref="ArgumentException">Thrown when <paramref name="type"/> is null or whitespace.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="title"/> is <c>null</c>.</exception>
+        public MdAdmonition(string type, MdSpan title, MdContainerBlockBase content) : this(type, title, (MdBlock)content)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MdAdmonition"/>.
+        /// </summary>
+        /// 
+        /// <param name="type">
+        /// The admonition's type. Any non-empty string is allowed.
+        /// Recommended values are <c>attention</c>, <c>caution</c>, <c>danger</c>, <c>error</c>,
+        /// <c>hint</c>, <c>important</c>, <c>note</c>, <c>tip</c> and <c>warning</c>
+        /// </param>
+        ///
+        /// <param name="content">
+        /// The admonition's content.
+        /// </param>
+        /// 
+        /// <exception cref="ArgumentException">Thrown when <paramref name="type"/> is null or whitespace.</exception>
+        public MdAdmonition(string type, MdList content) : this(type, MdEmptySpan.Instance, (MdBlock)content)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MdAdmonition"/>.
+        /// </summary>
+        /// 
+        /// <param name="type">
+        /// The admonition's type. Any non-empty string is allowed.
+        /// Recommended values are <c>attention</c>, <c>caution</c>, <c>danger</c>, <c>error</c>,
+        /// <c>hint</c>, <c>important</c>, <c>note</c>, <c>tip</c> and <c>warning</c>
+        /// </param>
+        ///
+        /// <param name="title">
+        /// The admonition's title. To create a admonition without title, use a different constructor overload.
+        /// </param>
+        ///
+        /// <param name="content">
+        /// The admonition's content.
+        /// </param>
+        ///
+        /// <exception cref="ArgumentException">Thrown when <paramref name="type"/> is null or whitespace.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="title"/> is <c>null</c>.</exception>
+        public MdAdmonition(string type, MdSpan title, MdList content) : this(type, title, (MdBlock)content)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MdAdmonition"/>.
+        /// </summary>
+        /// 
+        /// <param name="type">
+        /// The admonition's type. Any non-empty string is allowed.
+        /// Recommended values are <c>attention</c>, <c>caution</c>, <c>danger</c>, <c>error</c>,
+        /// <c>hint</c>, <c>important</c>, <c>note</c>, <c>tip</c> and <c>warning</c>
+        /// </param>
+        ///
+        /// <param name="content">
+        /// The admonition's content.
+        /// </param>
+        ///
+        /// <exception cref="ArgumentException">Thrown when <paramref name="type"/> is null or whitespace.</exception>
+        public MdAdmonition(string type, params MdBlock[] content) : this(type, MdEmptySpan.Instance, (IEnumerable<MdBlock>)content)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MdAdmonition"/>.
+        /// </summary>
+        ///
+        /// <param name="type">
+        /// The admonition's type. Any non-empty string is allowed.
+        /// Recommended values are <c>attention</c>, <c>caution</c>, <c>danger</c>, <c>error</c>,
+        /// <c>hint</c>, <c>important</c>, <c>note</c>, <c>tip</c> and <c>warning</c>
+        /// </param>
+        ///
+        /// <param name="title">
+        /// The admonition's title. To create a admonition without title, use a different constructor overload.
+        /// </param>
+        ///
+        /// <param name="content">
+        /// The admonition's content.
+        /// </param>
+        /// 
+        /// <exception cref="ArgumentException">Thrown when <paramref name="type"/> is null or whitespace.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="title"/> is <c>null</c>.</exception>
+        public MdAdmonition(string type, MdSpan title, params MdBlock[] content) : this(type, title, (IEnumerable<MdBlock>)content)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MdAdmonition"/>.
+        /// </summary>
+        ///
+        /// <param name="type">
+        /// The admonition's type. Any non-empty string is allowed.
+        /// Recommended values are <c>attention</c>, <c>caution</c>, <c>danger</c>, <c>error</c>,
+        /// <c>hint</c>, <c>important</c>, <c>note</c>, <c>tip</c> and <c>warning</c>
+        /// </param>
+        ///
+        /// <param name="content">
+        /// The admonition's content.
+        /// </param>
+        /// 
+        /// <exception cref="ArgumentException">Thrown when <paramref name="type"/> is null or whitespace.</exception>
+        public MdAdmonition(string type, IEnumerable<MdBlock> content) : this(type, MdEmptySpan.Instance, content)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MdAdmonition"/>.
+        /// </summary>
+        ///
+        /// <param name="type">
+        /// The admonition's type. Any non-empty string is allowed.
+        /// Recommended values are <c>attention</c>, <c>caution</c>, <c>danger</c>, <c>error</c>,
+        /// <c>hint</c>, <c>important</c>, <c>note</c>, <c>tip</c> and <c>warning</c>
+        /// </param>
+        ///
+        /// <param name="title">
+        /// The admonition's title. To create a admonition without title, use a different constructor overload.
+        /// </param>
+        ///
+        /// <param name="content">
+        /// The admonition's content.
+        /// </param>
+        ///
+        /// <exception cref="ArgumentException">Thrown when <paramref name="type"/> is null or whitespace.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="title"/> is <c>null</c>.</exception>
+        public MdAdmonition(string type, MdSpan title, IEnumerable<MdBlock> content) : base(content)
+        {
+            if (String.IsNullOrWhiteSpace(type))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(type));
+
+            Type = type;
+            Title = title ?? throw new ArgumentNullException(nameof(title));
+        }
+
+
+        /// <inheritdoc />
+        public override bool DeepEquals(MdBlock other) => other is MdAdmonition containerBlock ? DeepEquals(containerBlock) : false;
+
+        internal override void Accept(IBlockVisitor visitor) => visitor.Visit(this);
+    }
+}

--- a/src/MarkdownGenerator/FactoryMethods.cs
+++ b/src/MarkdownGenerator/FactoryMethods.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Grynwald.MarkdownGenerator.Extensions;
 
 namespace Grynwald.MarkdownGenerator
 {
@@ -52,9 +53,18 @@ namespace Grynwald.MarkdownGenerator
         /// Creates a new instance of <see cref="MdDocument"/> with the specified content.
         /// </summary>
         /// <remarks>
-        /// MdBlockQuote implements <see cref="IEnumerable{MdListItem}"/> so this constructor is necessary to prevent ambiguities.
+        /// MdBlockQuote implements <see cref="IEnumerable{MdBlock}"/> so this constructor is necessary to prevent ambiguities.
         /// </remarks>
         public static MdDocument Document(MdBlockQuote blockQuote) => new MdDocument(blockQuote);
+
+        /// <summary>
+        /// Creates a new instance of <see cref="MdDocument"/> with the specified content.
+        /// </summary>
+        /// <remarks>
+        /// MdAdmonition implements <see cref="IEnumerable{MdBlock}"/> so this constructor is necessary to prevent ambiguities.
+        /// </remarks>
+        public static MdDocument Document(MdAdmonition admonition) => new MdDocument(admonition);
+
 
         /// <summary>
         /// Creates a new instance if <see cref="MdDocumentSet"/>.

--- a/src/MarkdownGenerator/Internal/_DocumentSerializer/DocumentSerializer.Extensions.cs
+++ b/src/MarkdownGenerator/Internal/_DocumentSerializer/DocumentSerializer.Extensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using Grynwald.MarkdownGenerator.Extensions;
+
+namespace Grynwald.MarkdownGenerator.Internal
+{
+    internal partial class DocumentSerializer
+    {
+        public void Visit(MdAdmonition admonition)
+        {
+            var title = admonition.Title.ToString();
+
+            if (String.IsNullOrEmpty(title))
+            {
+                m_Writer.WriteLine($"!!! {admonition.Type.ToLower()}");
+            }
+            else
+            {
+                m_Writer.WriteLine($"!!! {admonition.Type.ToLower()} \"{title}\"");
+            }
+
+            m_Writer.PushPrefixHandler(new AdmonitionPrefixHandler());
+
+            if(admonition.Any())
+                m_Writer.SuppressNextBlankLine();
+
+            foreach (var block in admonition)
+            {
+                block.Accept(this);
+            }
+
+            m_Writer.PopPrefixHandler();            
+        }
+    }
+}

--- a/src/MarkdownGenerator/Internal/_DocumentSerializer/DocumentSerializer.Extensions.cs
+++ b/src/MarkdownGenerator/Internal/_DocumentSerializer/DocumentSerializer.Extensions.cs
@@ -8,6 +8,8 @@ namespace Grynwald.MarkdownGenerator.Internal
     {
         public void Visit(MdAdmonition admonition)
         {
+            m_Writer.RequestBlankLine();
+
             var title = admonition.Title.ToString();
 
             if (String.IsNullOrEmpty(title))
@@ -29,7 +31,8 @@ namespace Grynwald.MarkdownGenerator.Internal
                 block.Accept(this);
             }
 
-            m_Writer.PopPrefixHandler();            
+            m_Writer.PopPrefixHandler();
+            m_Writer.RequestBlankLine();
         }
     }
 }

--- a/src/MarkdownGenerator/Internal/_DocumentSerializer/DocumentSerializer.cs
+++ b/src/MarkdownGenerator/Internal/_DocumentSerializer/DocumentSerializer.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Grynwald.MarkdownGenerator.Internal
 {
-    internal class DocumentSerializer : IBlockVisitor
+    internal partial class DocumentSerializer : IBlockVisitor
     {
         private static readonly char[] s_LineBreakChars = "\r\n".ToCharArray();
 

--- a/src/MarkdownGenerator/Internal/_DocumentSerializer/_PrefixHandlers/AdmonitionPrefixHandler.cs
+++ b/src/MarkdownGenerator/Internal/_DocumentSerializer/_PrefixHandlers/AdmonitionPrefixHandler.cs
@@ -1,0 +1,11 @@
+﻿namespace Grynwald.MarkdownGenerator.Internal
+{
+    internal class AdmonitionPrefixHandler : IPrefixHandler
+    {
+        public int PrefixLength => 4;
+
+        public string GetBlankLinePrefix() => "    ";
+
+        public string GetLinePrefix() => "    ";        
+    }
+}

--- a/src/MarkdownGenerator/Internal/_TextWriter/PrefixTextWriter.cs
+++ b/src/MarkdownGenerator/Internal/_TextWriter/PrefixTextWriter.cs
@@ -11,6 +11,7 @@ namespace Grynwald.MarkdownGenerator.Internal
         private readonly TextWriter m_InnerWriter;
         private bool m_AnyLinesWritten = false;
         private bool m_BlankLineRequested = false;
+        private bool m_SupressNextBlankLine = false;
         private readonly LinkedList<IPrefixHandler> m_PrefixHandlers = new LinkedList<IPrefixHandler>();
 
 
@@ -49,9 +50,16 @@ namespace Grynwald.MarkdownGenerator.Internal
             LineWritten?.Invoke(this, EventArgs.Empty);
             m_AnyLinesWritten = true;
         }
-        
+
+        public void SuppressNextBlankLine() => m_SupressNextBlankLine = true;
+
         public void RequestBlankLine()
         {
+            if(m_SupressNextBlankLine)
+            {
+                m_SupressNextBlankLine = false;
+                return;
+            }
             m_BlankLineRequested = true;
             BlankLineRequested?.Invoke(this, EventArgs.Empty);
         }

--- a/src/MarkdownGenerator/Internal/_Visitors/IBlockVisitor.Extensions.cs
+++ b/src/MarkdownGenerator/Internal/_Visitors/IBlockVisitor.Extensions.cs
@@ -1,0 +1,9 @@
+﻿using Grynwald.MarkdownGenerator.Extensions;
+
+namespace Grynwald.MarkdownGenerator.Internal
+{
+    internal partial interface IBlockVisitor
+    {    
+        void Visit(MdAdmonition codeBlock);
+    }
+}

--- a/src/MarkdownGenerator/Internal/_Visitors/IBlockVisitor.cs
+++ b/src/MarkdownGenerator/Internal/_Visitors/IBlockVisitor.cs
@@ -1,6 +1,6 @@
 ﻿namespace Grynwald.MarkdownGenerator.Internal
 {
-    internal interface IBlockVisitor
+    internal partial interface IBlockVisitor
     {
         void Visit(MdHeading heading);
 

--- a/src/MarkdownGenerator/SyntaxVisualizer.cs
+++ b/src/MarkdownGenerator/SyntaxVisualizer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Grynwald.MarkdownGenerator.Extensions;
 using Grynwald.MarkdownGenerator.Internal;
 
 namespace Grynwald.MarkdownGenerator
@@ -106,10 +107,12 @@ namespace Grynwald.MarkdownGenerator
 
             public void Visit(MdRawMarkdownSpan span) => CreateLeafNode(span);
 
+            public void Visit(MdAdmonition admonition) => VisitContainer(admonition);
+
 
             private void CreateLeafNode(object item)
             {
-                // push new node and immediatelly pop it from the stack as leaf nodes do not have childen
+                // push new node and immediately pop it from the stack as leaf nodes do not have children
                 PushNewNode(item);
                 PopNode();
             }

--- a/src/MarkdownGenerator/_Model/MdDocument.cs
+++ b/src/MarkdownGenerator/_Model/MdDocument.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Grynwald.MarkdownGenerator.Extensions;
 using Grynwald.MarkdownGenerator.Internal;
 
 namespace Grynwald.MarkdownGenerator
@@ -53,6 +54,7 @@ namespace Grynwald.MarkdownGenerator
         public MdDocument(MdList list) : this((MdBlock)list)
         { }
 
+
         /// <summary>
         /// Initializes a new instance of <see cref="MdDocument"/> with the specified content.
         /// </summary>
@@ -62,6 +64,14 @@ namespace Grynwald.MarkdownGenerator
         public MdDocument(MdBlockQuote list) : this((MdBlock)list)
         { }
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="MdDocument"/> with the specified content.
+        /// </summary>
+        /// <remarks>
+        /// MdAdmonition implements <see cref="IEnumerable{MdBlock}"/> so this constructor is necessary to prevent ambiguities.
+        /// </remarks>
+        public MdDocument(MdAdmonition admonition) : this((MdBlock)admonition)
+        { }
 
         /// <summary>
         /// Saves the document to the specified file.

--- a/src/MarkdownGenerator/_Model/_Options/MdSerializationOptions.cs
+++ b/src/MarkdownGenerator/_Model/_Options/MdSerializationOptions.cs
@@ -8,8 +8,9 @@
     /// </summary>
     public class MdSerializationOptions
     {
-        public static readonly MdSerializationOptions Default = new MdSerializationOptions();
+        //TODO: Make class immutable, prevent Default settings to be changed
 
+        public static readonly MdSerializationOptions Default = new MdSerializationOptions();
 
         /// <summary>
         /// Gets or sets the style for emphasized and strongly emphasized text


### PR DESCRIPTION
`MdAdmonition` adds support for generating admonitions/notes using the "Admonition" extension for Python Markdown