### PR TITLE
fix: Fix serialization of blank lines in code blocks

### DIFF
--- a/src/MarkdownGenerator.Test/Internal/_DocumentSerializer/DocumentSerializerTest.cs
+++ b/src/MarkdownGenerator.Test/Internal/_DocumentSerializer/DocumentSerializerTest.cs
@@ -290,6 +290,36 @@ namespace Grynwald.MarkdownGenerator.Test.Internal
             );
 
         [Fact]
+        public void Code_blocks_are_serialized_as_expected_03() =>
+            AssertToStringEquals(
+                """
+                ```lang
+                Line 1
+                
+                Line 2
+                
+                
+                Line 3
+                
+                ```
+
+                """,
+                new MdDocument(new MdCodeBlock(
+                    """
+                    Line 1
+
+                    Line 2
+
+
+                    Line 3
+
+                    """,
+                    "lang"
+                ))
+            );
+
+
+        [Fact]
         public void Tables_are_serialized_as_expected_01() =>
             AssertToStringEquals(
                 "| Column1 | Column2 |\r\n" +

--- a/src/MarkdownGenerator/Internal/_DocumentSerializer/DocumentSerializer.cs
+++ b/src/MarkdownGenerator/Internal/_DocumentSerializer/DocumentSerializer.cs
@@ -7,7 +7,7 @@ namespace Grynwald.MarkdownGenerator.Internal
 {
     internal partial class DocumentSerializer : IBlockVisitor
     {
-        private static readonly char[] s_LineBreakChars = "\r\n".ToCharArray();
+        private static readonly string[] s_LineBreaks = { "\n", "\r\n" };
 
         private readonly PrefixTextWriter m_Writer;
         private readonly MdSerializationOptions m_Options;
@@ -128,7 +128,7 @@ namespace Grynwald.MarkdownGenerator.Internal
         {
             m_Writer.RequestBlankLine();
 
-            var lines = paragraph.Text.ToString(m_Options).Split(s_LineBreakChars, StringSplitOptions.RemoveEmptyEntries);
+            var lines = paragraph.Text.ToString(m_Options).Split(s_LineBreaks, StringSplitOptions.RemoveEmptyEntries);
 
             // skip paragraph if it is empty
             if (lines.Length == 0)
@@ -278,7 +278,7 @@ namespace Grynwald.MarkdownGenerator.Internal
 
             m_Writer.WriteLine($"{codeFence}{codeBlock.InfoString ?? ""}");
 
-            var lines = codeBlock.Text.Split(s_LineBreakChars, StringSplitOptions.RemoveEmptyEntries);
+            var lines = codeBlock.Text.Split(s_LineBreaks, StringSplitOptions.None);
             foreach (var line in lines)
             {
                 m_Writer.WriteLine(line);


### PR DESCRIPTION
Blank lines in the content of MdCodeBlock block were being omitted when saving Markdown.

Backport of #201 to version 2.5

See-Also: #201